### PR TITLE
Use git submodules to fetch `trantor`

### DIFF
--- a/Formula/drogon.rb
+++ b/Formula/drogon.rb
@@ -1,8 +1,10 @@
 class Drogon < Formula
   desc "HTTP(S) Web Application Framework (C++14/17 based)"
   homepage "https://drogon.docsforge.com"
-  url "https://github.com/drogonframework/drogon/archive/refs/tags/v1.7.2.tar.gz"
-  sha256 "a682fafc3619ba69d3d9278a80f6a386d1effcc3692b47e976de7cf9ff89d6b8"
+  # pull from git tag to get submodules
+  url "https://github.com/drogonframework/drogon.git",
+      tag:      "v1.7.2",
+      revision: "b68aeb43ae092c83e7e775c83c8ed7764418af0e"
   license "MIT"
   head "https://github.com/drogonframework/drogon.git"
 
@@ -14,15 +16,8 @@ class Drogon < Formula
   depends_on "ossp-uuid"
   depends_on "zlib"
 
-  resource "trantor" do
-    url "https://github.com/an-tao/trantor.git",
-        revision: "bef06c4f5e2dfc80303aee06a12770d09d5e8f5b"
-  end
-
   def install
     # TODO: Verify Parallelization - https://github.com/drogonframework/homebrew-drogon/issues/4
-    # head gets trantor as a git submodule
-    (buildpath/"trantor").install resource("trantor")
     system "cmake", "-B", "build", "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
Homebrew supports fetching submodules by using git URL.

Ref: https://github.com/Homebrew/homebrew-core/blob/b2ba529053ad1b218e11d10825d6ec23d37b2b44/Formula/clarinet.rb#L4-L7

---

Tested on my computer:

```console
$ brew install --build-from-source drogon
==> Cloning https://github.com/drogonframework/drogon.git
Cloning into '/Users/tmp/Library/Caches/Homebrew/drogon--git'...
==> Checking out tag v1.7.2
HEAD is now at b68aeb4 add v1.7.2 link
Submodule 'trantor' (https://github.com/an-tao/trantor.git) registered for path 'trantor'
Cloning into '/Users/tmp/Library/Caches/Homebrew/drogon--git/trantor'...
Submodule path 'trantor': checked out 'bef06c4f5e2dfc80303aee06a12770d09d5e8f5b'
/Users/tmp/Library/Caches/Homebrew/drogon--git/trantor
...
```