### PR TITLE
Simplify description

### DIFF
--- a/Formula/drogon.rb
+++ b/Formula/drogon.rb
@@ -1,5 +1,5 @@
 class Drogon < Formula
-  desc "A modern C++ web application framework. Fast, easy to use, feature-rich and cross-platform"
+  desc "Modern C++ web application framework"
   homepage "https://drogon.org"
   # pull from git tag to get submodules
   url "https://github.com/drogonframework/drogon.git",


### PR DESCRIPTION
due to complaints by `brew audit`:

  * 2: col 8: Description is too long. It should be less than 80 characters. The current length is 90.
  * 2: col 9: Description shouldn't start with an article.