### PR TITLE
Remove parallelism TODO comment

### DIFF
--- a/Formula/drogon.rb
+++ b/Formula/drogon.rb
@@ -16,7 +16,6 @@ class Drogon < Formula
   depends_on "zlib"
 
   def install
-    # TODO: Verify Parallelization - https://github.com/drogonframework/homebrew-drogon/issues/4
     system "cmake", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
Closes https://github.com/drogonframework/homebrew-drogon/issues/4

Parallelism appears to be on by default: https://docs.brew.sh/Formula-Cookbook#bad-makefiles